### PR TITLE
Skip edge compiler in next 12

### DIFF
--- a/packages/next-plugin-preact/index.js
+++ b/packages/next-plugin-preact/index.js
@@ -18,7 +18,7 @@ module.exports = function withPreact(nextConfig = {}) {
   return withPrefresh(
     Object.assign({}, nextConfig, {
       webpack(config, options) {
-        const { dev, isServer, defaultLoaders } = options;
+        const { dev, isServer, nextRuntime, defaultLoaders } = options;
 
         // Disable package exports field resolution in webpack. It can lead
         // to dual package hazards where packages are imported twice: One
@@ -58,7 +58,7 @@ module.exports = function withPreact(nextConfig = {}) {
         aliases['react-ssr-prepass'] = 'preact-ssr-prepass';
 
         // Automatically inject Preact DevTools
-        if (dev) {
+        if (dev && nextRuntime !== 'edge') {
           const prependToEntry = isServer ? 'pages/_document' : 'main.js';
 
           const rtsVersion = require('preact-render-to-string/package.json')


### PR DESCRIPTION
Latest version (12.0.6) of next.js introduces a new webpack compiler under `'edge'` runtime. The preact debug chunk only works for entries from server and client compiler, so that we skip the prepending in `'edge'` runtime compiler

Related to #60